### PR TITLE
Interval for getting badge counts

### DIFF
--- a/client/src/inputs/navBar.js
+++ b/client/src/inputs/navBar.js
@@ -34,18 +34,26 @@ export default function NavigationBar() {
   };
 
   const matches = useMediaQuery('(max-width: 768px)');
+
+  const getBadgeCounts = async () => {
+
+    var groups = (await axios.get('/api/user/groups_count')).data;
+    setGroupsCount(groups);
+
+    var requests = (await axios.get('/api/user/requests_count')).data;
+    setRequestsCount(requests);
+
+    var notifs = (await axios.get('/api/user/unread_notif_count')).data;
+    setNotifCount(notifs);
+
+  };
   
   useEffect(() => {
     async function fetchData() {
       
-      var groups = (await axios.get('/api/user/groups_count')).data;
-      setGroupsCount(groups);
+      getBadgeCounts();
+      setInterval(getBadgeCounts, 1000 * 60 * 2);
 
-      var requests = (await axios.get('/api/user/requests_count')).data;
-      setRequestsCount(requests);
-
-      var notifs = (await axios.get('/api/user/unread_notif_count')).data;
-      setNotifCount(notifs);
     }
     fetchData();
   });


### PR DESCRIPTION
Fixes #59
Interval set to call API for getting notification counts and update badges without the need to refresh the page.